### PR TITLE
[10.x] Update PHP version to 8.1 in Valet documentation

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -105,7 +105,7 @@ Valet will automatically start its required services each time your machine boot
 Valet allows you to switch PHP versions using the `valet use php@version` command. Valet will install the specified PHP version via Homebrew if it is not already installed:
 
 ```shell
-valet use php@7.2
+valet use php@8.1
 
 valet use php
 ```
@@ -113,7 +113,7 @@ valet use php
 You may also create a `.valetphprc` file in the root of your project. The `.valetphprc` file should contain the PHP version the site should use:
 
 ```shell
-php@7.2
+php@8.1
 ```
 
 Once this file has been created, you may simply execute the `valet use` command and the command will determine the site's preferred PHP version by reading the file.


### PR DESCRIPTION
As the minimum PHP version for Laravel 10 is `8.1`, this pull request updates the version of PHP to `8.1` in the Valet documentation. 